### PR TITLE
block sizes proportional to pascals triangle

### DIFF
--- a/pkg/DESCRIPTION
+++ b/pkg/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: blockrand
 Type: Package
 Title: Randomization for Block Random Clinical Trials
-Version: 1.6
+Version: 1.7
 Date: 2023-08-21
 Author: Greg Snow <538280@gmail.com>
 Maintainer: Greg Snow <538280@gmail.com>

--- a/pkg/R/blockrand.R
+++ b/pkg/R/blockrand.R
@@ -1,7 +1,8 @@
 "blockrand" <-
 function(n, num.levels=2, levels=LETTERS[seq(length=num.levels)],
                       id.prefix, stratum, block.sizes=1:4, block.prefix,
-         uneq.beg=FALSE, uneq.mid=FALSE, uneq.min=0,uneq.maxit=10){
+         uneq.beg=FALSE, uneq.mid=FALSE, uneq.min=0,uneq.maxit=10,
+         pascal = TRUE){
 
     treat <- vector(mode(levels))
     block.id <- numeric(0)
@@ -28,7 +29,13 @@ function(n, num.levels=2, levels=LETTERS[seq(length=num.levels)],
         }
 
         block.n <- if(length(block.sizes) > 1 ) {
-            sample(block.sizes,1)
+            if(pascal) {
+              pascalvals <- choose(length(block.sizes)-1, 0:(length(block.sizes)-1))
+              p <- pascalvals / length(block.sizes)
+            } else {
+              p <- rep(1 / length(block.sizes), length(block.sizes))
+            }
+            sample(block.sizes, 1, prob = p)
         } else {
             block.sizes
         }

--- a/pkg/man/blockrand.Rd
+++ b/pkg/man/blockrand.Rd
@@ -34,6 +34,7 @@ uneq.beg=FALSE, uneq.mid=FALSE, uneq.min=0, uneq.maxit=10)
   \item{uneq.min}{ what is the minimum difference between the most and
     least common levels in an unequal block }
   \item{uneq.maxit}{ maximum number of tries to get uneq.min difference }
+  \item{pascal}{ sample block sizes according to Pascal's triangle }
 }
 \details{
   This function will randomize subjects to the specified treatments
@@ -63,6 +64,12 @@ uneq.beg=FALSE, uneq.mid=FALSE, uneq.min=0, uneq.maxit=10)
   not be exactly equal (but still similar).  This makes it more
   difficult to anticipate future assignments as the numbers will not
   return to equality at the end of each block.
+
+  Too many small blocks can increase the risk of breaking the blind.
+  Conversely, too many large blocks can lead to imbalance in the event
+  that recruitment is stopped mid-block. If \code{pascal = TRUE} is used,
+  block sizes are sampled in proportion to the elements of Pascal's
+  triangle. If \code{pascal = FALSE}, all block sizes are equally likely.
 
   For stratified studies the \code{blockrand} function should run once
   each for each stratum using the \code{stratum} argument to specify the


### PR DESCRIPTION
Some other systems, e.g. ralloc for Stata, use Pascal’s triangle to downweight small and large blocks, upweighting the intermediate sized blocks. This has the effect of making it more difficult to break the blind (as small blocks are less common) and reduces the risk of imbalance should the trial terminate in the middle of block (as large blocks are less common). These are both desirable features…

PS. this is the same change I emailed you about yesterday, i only just found the repo...